### PR TITLE
Explicit namespace root for \Exception

### DIFF
--- a/src/Repos/RemoteLogsRepo.php
+++ b/src/Repos/RemoteLogsRepo.php
@@ -15,7 +15,7 @@ class RemoteLogsRepo implements LogsRepoInterface
         $this->config = $config;
 
         if ($this->config['enabled_remote'] && !$this->config['remote_disk']) {
-            throw new Exception("remote_disk not configured for Laravel Log Keeper");
+            throw new \Exception("remote_disk not configured for Laravel Log Keeper");
         }
 
         $this->localLogPath = storage_path('logs');


### PR DESCRIPTION
Without the slash, running `php artisan laravel-log-keeper` with no configuration results in the following exception being raised:
[Symfony\Component\Debug\Exception\FatalErrorException]  
Class 'MathiasGrimm\LaravelLogKeeper\Repos\Exception' not found
